### PR TITLE
Bug/#26 점포명 변경 시 User.storeInfos[].name(캐시)이 갱신되지 않는 문제

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@ Firebase, Riverpod, GoRouter, Clean Architecture, MVVM을 사용하는 공간대
 - Firebase 서비스: Firestore, Authentication, Crashlytics, Cloud Message, Analytics, App Check
 - 소셜 로그인: Google, Apple
   - 정식 출시 후 Naver, Kakao 추가 예정
+- **배포 예정 시점**: 2026-08 말 ~ 2026-09 초 (아직 정식 출시 전, 프로덕션 데이터 없음)
 
 ## 코드 스타일
 - Flutter/Dart 사용
@@ -144,6 +145,7 @@ Firestore Security Rules가 주 보안 레이어. UseCase 레벨 검증은 현�
 - color 폴백: `StoreColor.red` (currentUser가 storeById에 해당 점포 없을 때)
 
 ## 중요 사항
+- 정식 출시 전(배포 예정 2026-08 말 ~ 2026-09 초)이므로 Firestore 스키마 변경 시 기존 데이터 마이그레이션은 고려하지 않아도 됨
 - API Key 관련 문자열은 gitignore 처리되어있는 별도 파일로 분리하고 import하여 사용
 - `Future.wait([f1, f2])` — f1, f2의 **반환 타입이 다르면** `List<Object?>`로 추론됨 → 타입별 별도 Future 변수로 분리할 것
   ```dart

--- a/lib/data/data_sources/store_data_source.dart
+++ b/lib/data/data_sources/store_data_source.dart
@@ -25,7 +25,13 @@ abstract interface class StoreDataSource {
   Future<StoreModel?> getStore(String storeId);
 
   /// 점포 정보 수정
-  Future<void> updateStore(String storeId, Map<String, dynamic> data);
+  /// - `memberUids`: `data`에 `name`이 포함된 경우, 해당 uid 목록(멤버+대기 멤버)의
+  ///   `storeById.{storeId}.name` 캐시를 함께 동기화한다.
+  Future<void> updateStore(
+    String storeId,
+    Map<String, dynamic> data,
+    List<String> memberUids,
+  );
 
   /// 점포 삭제 (Soft Delete)
   Future<void> softDeleteStore(String storeId);
@@ -148,12 +154,29 @@ class StoreFirestoreDataSource extends FirestoreDataSourceBase
   }
 
   @override
-  Future<void> updateStore(String storeId, Map<String, dynamic> data) async {
+  Future<void> updateStore(
+    String storeId,
+    Map<String, dynamic> data,
+    List<String> memberUids,
+  ) async {
     try {
+      final batch = _firestore.batch();
+
       final updates = Map<String, dynamic>.from(data);
       updates['updatedAt'] = FieldValue.serverTimestamp();
+      batch.update(_storeDocRef(storeId), updates);
 
-      await _storeDocRef(storeId).update(updates);
+      final newName = data['name'] as String?;
+      if (newName != null) {
+        for (final uid in memberUids) {
+          batch.update(_firestore.collection('users').doc(uid), {
+            'storeById.$storeId.name': newName,
+            'updatedAt': FieldValue.serverTimestamp(),
+          });
+        }
+      }
+
+      await batch.commit();
     } catch (e) {
       throw handleFirestoreError(e);
     }

--- a/lib/data/repositories/store_repository_impl.dart
+++ b/lib/data/repositories/store_repository_impl.dart
@@ -108,7 +108,17 @@ class StoreRepositoryImpl implements StoreRepository {
     try {
       final storeModel = StoreModel.fromEntity(store);
 
-      await _storeDataSource.updateStore(store.id, storeModel.toEditableJson());
+      // 점포명 변경이 전체 멤버(승인+대기)의 storeById.name 캐시에 반영되도록 uid 목록 전달
+      final memberUids = {
+        ...store.memberInfos.map((info) => info.user.id),
+        ...store.waitingMemberInfos.map((info) => info.user.id),
+      }.toList();
+
+      await _storeDataSource.updateStore(
+        store.id,
+        storeModel.toEditableJson(),
+        memberUids,
+      );
 
       // color.name은 Dart 식별자('green')를 반환하므로 toJson()으로 JSON 값('GREEN') 직렬화
       final colorJson = UserStoreInfoModel(

--- a/test/data/data_sources/store_data_source_test.dart
+++ b/test/data/data_sources/store_data_source_test.dart
@@ -215,7 +215,7 @@ void main() {
       await _seedUserDoc(fakeFirestore, uid);
       final created = await dataSource.createStore(_testStore(), uid, _creatorInfo);
 
-      await dataSource.updateStore(created.id, {'name': '변경된 점포명'});
+      await dataSource.updateStore(created.id, {'name': '변경된 점포명'}, []);
 
       final updated = await dataSource.getStore(created.id);
       expect(updated?.name, '변경된 점포명');
@@ -226,11 +226,50 @@ void main() {
       await _seedUserDoc(fakeFirestore, uid);
       final created = await dataSource.createStore(_testStore(), uid, _creatorInfo);
 
-      await dataSource.updateStore(created.id, {'name': '변경된 점포명'});
+      await dataSource.updateStore(created.id, {'name': '변경된 점포명'}, []);
 
       final updated = await dataSource.getStore(created.id);
       expect(updated?.address, '서울시 강남구 테헤란로 1');
       expect(updated?.addressDetail, '101호');
+    });
+
+    test('memberUids로 전달된 유저들의 storeById.name 캐시가 함께 갱신된다', () async {
+      final storeId = FirestoreEmulatorHelper.generateId();
+      final adminUid = FirestoreEmulatorHelper.generateId();
+      final staffUid = FirestoreEmulatorHelper.generateId();
+      await _seedUserWithStore(fakeFirestore, adminUid, storeId);
+      await _seedUserWithStore(fakeFirestore, staffUid, storeId);
+      await _seedStoreWithMember(fakeFirestore, storeId, staffUid);
+
+      await dataSource.updateStore(
+        storeId,
+        {'name': '변경된 점포명'},
+        [adminUid, staffUid],
+      );
+
+      final adminDoc = await fakeFirestore.collection('users').doc(adminUid).get();
+      final staffDoc = await fakeFirestore.collection('users').doc(staffUid).get();
+      final adminStoreById = adminDoc.data()?['storeById'] as Map<String, dynamic>?;
+      final staffStoreById = staffDoc.data()?['storeById'] as Map<String, dynamic>?;
+      expect(adminStoreById?[storeId]['name'], '변경된 점포명');
+      expect(staffStoreById?[storeId]['name'], '변경된 점포명');
+    });
+
+    test('data에 name이 없으면 memberUids의 storeById.name을 건드리지 않는다', () async {
+      final storeId = FirestoreEmulatorHelper.generateId();
+      final staffUid = FirestoreEmulatorHelper.generateId();
+      await _seedUserWithStore(fakeFirestore, staffUid, storeId);
+      await _seedStoreWithMember(fakeFirestore, storeId, staffUid);
+
+      await dataSource.updateStore(
+        storeId,
+        {'address': '변경된 주소'},
+        [staffUid],
+      );
+
+      final staffDoc = await fakeFirestore.collection('users').doc(staffUid).get();
+      final staffStoreById = staffDoc.data()?['storeById'] as Map<String, dynamic>?;
+      expect(staffStoreById?[storeId]['name'], '테스트 점포');
     });
   });
 

--- a/test/data/repositories/store_repository_integration_test.dart
+++ b/test/data/repositories/store_repository_integration_test.dart
@@ -149,6 +149,56 @@ void main() {
       expect(fetched.getRight().toNullable()!.name, '변경된 점포명');
     });
 
+    test('점포명 변경 시 다른 멤버(staff)의 storeById.name 캐시도 함께 갱신된다', () async {
+      final ownerUid = FirestoreEmulatorHelper.generateId();
+      final staffUid = FirestoreEmulatorHelper.generateId();
+      await _seedUserDoc(fakeFirestore, ownerUid);
+      await _seedUserDoc(fakeFirestore, staffUid);
+      final adminUser = User(
+        id: ownerUid,
+        name: '테스트 유저',
+        email: 'test@example.com',
+        nickname: null,
+        authProviders: [],
+        storeInfos: [],
+      );
+
+      final created = await repository.createStore(
+        store: _testStoreEntity(ownerUid, adminUser),
+        color: StoreColor.blue,
+        memo: '',
+      );
+      final createdStore = created.getRight().toNullable()!;
+
+      await repository.requestJoinStore(
+        storeId: createdStore.id,
+        uid: staffUid,
+        role: UserRole.staff,
+        color: StoreColor.red,
+        storeAlias: '통합 테스트 점포',
+        memo: '',
+      );
+      await repository.approveMember(
+        storeId: createdStore.id,
+        uid: staffUid,
+        role: UserRole.staff,
+      );
+
+      final fetched = await repository.getStore(createdStore.id);
+      final storeWithStaff = fetched.getRight().toNullable()!;
+
+      await repository.updateStore(
+        store: storeWithStaff.copyWith(name: '변경된 점포명'),
+        uid: ownerUid,
+        color: StoreColor.green,
+        memo: '',
+      );
+
+      final staffDoc = await fakeFirestore.collection('users').doc(staffUid).get();
+      final staffStoreById = staffDoc.data()?['storeById'] as Map<String, dynamic>?;
+      expect(staffStoreById?[createdStore.id]['name'], '변경된 점포명');
+    });
+
     test('updateStore 후 users 컬렉션의 storeById에 color, memo가 반영된다', () async {
       final uid = FirestoreEmulatorHelper.generateId();
       await _seedUserDoc(fakeFirestore, uid);

--- a/test/data/repositories/store_repository_update_test.dart
+++ b/test/data/repositories/store_repository_update_test.dart
@@ -7,6 +7,7 @@ import 'package:studio_chance/data/models/store_member_info_model.dart';
 import 'package:studio_chance/data/models/store_model.dart';
 import 'package:studio_chance/data/models/user_store_info_model.dart';
 import 'package:studio_chance/data/repositories/store_repository_impl.dart';
+import 'package:studio_chance/domain/entities/store_member_info.dart';
 import 'package:studio_chance/domain/enums/store_color.dart';
 import 'package:studio_chance/domain/enums/user_role.dart';
 
@@ -49,7 +50,7 @@ void main() {
   group('updateStore', () {
     test('StoreDataSource와 UserDataSource가 올바른 파라미터로 호출된다', () async {
       when(
-        () => mockStoreDataSource.updateStore(any(), any()),
+        () => mockStoreDataSource.updateStore(any(), any(), any()),
       ).thenAnswer((_) async {});
       when(
         () => mockUserDataSource.updateStoreInfo(any(), any(), any()),
@@ -67,6 +68,7 @@ void main() {
       // 점포 문서 업데이트 호출 확인
       final capturedStoreArgs = verify(
         () => mockStoreDataSource.updateStore(
+          captureAny(),
           captureAny(),
           captureAny(),
         ),
@@ -95,9 +97,47 @@ void main() {
       expect(userStoreData['memo'], '새 메모');
     });
 
+    test('store의 memberInfos, waitingMemberInfos uid가 memberUids로 전달된다', () async {
+      when(
+        () => mockStoreDataSource.updateStore(any(), any(), any()),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockUserDataSource.updateStoreInfo(any(), any(), any()),
+      ).thenAnswer((_) async {});
+
+      final storeWithMembers = fakeStore.copyWith(
+        memberInfos: [
+          StoreMemberInfo(user: fakeUser, role: UserRole.admin),
+        ],
+        waitingMemberInfos: [
+          StoreMemberInfo(
+            user: fakeUser.copyWith(id: 'waiting-user-456'),
+            role: UserRole.staff,
+          ),
+        ],
+      );
+
+      await repository.updateStore(
+        store: storeWithMembers,
+        uid: fakeUser.id,
+        color: StoreColor.blue,
+        memo: '새 메모',
+      );
+
+      final capturedStoreArgs = verify(
+        () => mockStoreDataSource.updateStore(
+          captureAny(),
+          captureAny(),
+          captureAny(),
+        ),
+      ).captured;
+      final memberUids = capturedStoreArgs[2] as List<String>;
+      expect(memberUids, containsAll([fakeUser.id, 'waiting-user-456']));
+    });
+
     test('StoreDataSource 실패 시 left(exception)를 반환한다', () async {
       when(
-        () => mockStoreDataSource.updateStore(any(), any()),
+        () => mockStoreDataSource.updateStore(any(), any(), any()),
       ).thenThrow(Exception('Firestore 오류'));
 
       final result = await repository.updateStore(
@@ -115,7 +155,7 @@ void main() {
 
     test('UserDataSource 실패 시 left(exception)를 반환한다', () async {
       when(
-        () => mockStoreDataSource.updateStore(any(), any()),
+        () => mockStoreDataSource.updateStore(any(), any(), any()),
       ).thenAnswer((_) async {});
       when(
         () => mockUserDataSource.updateStoreInfo(any(), any(), any()),


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #26

<br>

## 📝 작업 내용
- `StoreRepositoryImpl.updateStore`가 `UserDataSource.updateStoreInfo`에 `color`/`memo`만 전달하고 `name`을 누락해, 점포명을 변경해도 각 유저 문서의 `storeInfos.name`(캐시)이 갱신되지 않던 문제 수정
- `StoreDataSource.updateStore`에 `memberUids` 파라미터를 추가해, 점포 문서 갱신과 승인/대기 멤버 전체의 `storeById.{storeId}.name` 캐시 동기화를 하나의 Firestore batch로 원자적으로 처리
- 기존에는 리네임을 요청한 유저 한 명의 캐시만 갱신되고 다른 멤버는 그대로였던 한계도 함께 해소
- `StoreDataSource`/`StoreRepositoryImpl` 관련 단위·통합 테스트 추가

<br>

## 📸 스크린샷
- 데이터 계층 로직 수정으로 UI 변경 없음

<br>