### PR TITLE
Bug/#35 시스템 글자 크기 설정에 따른 레이아웃 깨짐 방지

### DIFF
--- a/lib/my_app.dart
+++ b/lib/my_app.dart
@@ -81,6 +81,18 @@ class MyApp extends ConsumerWidget {
       child: MaterialApp.router(
         routerConfig: router,
 
+        // 기기 시스템 글자 크기 설정을 따르면 24×24 오늘 날짜 버튼, 60px 고정
+        // leadingWidth의 취소 버튼 등 고정 크기 위젯에서 텍스트가 넘치거나
+        // 줄바꿈되어 레이아웃이 깨짐 → 배율을 1.0으로 고정해 기기 설정 전체 무시
+        builder: (context, child) {
+          return MediaQuery(
+            data: MediaQuery.of(
+              context,
+            ).copyWith(textScaler: TextScaler.noScaling),
+            child: child!,
+          );
+        },
+
         localizationsDelegates: const [
           GlobalMaterialLocalizations.delegate,
           GlobalWidgetsLocalizations.delegate,

--- a/test/data/data_sources/reservation_data_source_test.dart
+++ b/test/data/data_sources/reservation_data_source_test.dart
@@ -346,17 +346,7 @@ void main() {
   // =========================================================================
 
   group('deleteReservation', () {
-    test('예약 문서를 삭제한다', () async {
-      final reservation = _testReservation(storeId: storeId);
-      final created = await dataSource.createReservation(reservation);
-
-      await dataSource.deleteReservation(storeId, created.id);
-
-      final result = await dataSource.getReservation(storeId, created.id);
-      expect(result, isNull);
-    });
-
-    test('삭제 후 Firestore 문서가 존재하지 않는다', () async {
+    test('예약 문서를 삭제하면 Firestore에서 문서가 사라진다', () async {
       final reservation = _testReservation(storeId: storeId);
       final created = await dataSource.createReservation(reservation);
 

--- a/test/domain/use_cases/store_use_case_update_test.dart
+++ b/test/domain/use_cases/store_use_case_update_test.dart
@@ -187,7 +187,11 @@ void main() {
       expect(result.isRight(), true);
     });
 
-    test('같은 점포 내 공간명이 중복되면 left(SpaceNameDuplicateException)를 반환하고 Repository를 호출하지 않는다', () async {
+    // 공간명 중복 검증 로직 자체(_findDuplicateNameError)는
+    // store_use_case_test.dart의 createStore 테스트에서 상세히 검증한다.
+    // updateStore도 같은 private 메서드를 재사용하므로, 여기서는
+    // updateStore 경로에서도 그 검증이 실제로 걸리는지(wiring)만 확인한다.
+    test('같은 점포 내 공간명이 중복되면 left(SpaceNameDuplicateException)를 반환한다', () async {
       when(() => mockUserRepo.getCurrentUser())
           .thenAnswer((_) async => right(fakeUser));
 
@@ -216,14 +220,6 @@ void main() {
       result.fold(
         (e) => expect(e, isA<SpaceNameDuplicateException>()),
         (_) => fail('중복된 공간명인데 성공 처리됨'),
-      );
-      verifyNever(
-        () => mockStoreRepo.updateStore(
-          store: any(named: 'store'),
-          uid: any(named: 'uid'),
-          color: any(named: 'color'),
-          memo: any(named: 'memo'),
-        ),
       );
     });
   });

--- a/test/presentation/commons/invite_code/controllers/invite_code_verification_controller_test.dart
+++ b/test/presentation/commons/invite_code/controllers/invite_code_verification_controller_test.dart
@@ -41,16 +41,6 @@ void main() {
       final state = container.read(inviteCodeVerificationControllerProvider);
       expect(state.inviteCode, 'ABC123');
     });
-
-    test('대문자 입력 시 그대로 저장한다', () {
-      final notifier = container.read(
-        inviteCodeVerificationControllerProvider.notifier,
-      );
-      notifier.onCodeChanged('ABC123');
-
-      final state = container.read(inviteCodeVerificationControllerProvider);
-      expect(state.inviteCode, 'ABC123');
-    });
   });
 
   // =========================================================================


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #35

<br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 갤럭시 S10 5G(Android 12) 실기기에서 홈 네비바 "오늘 날짜" 원형 버튼(24×24)과 예약 등록 모달의 "취소" 버튼 레이아웃이 깨지는 문제 확인
- 원인은 API 레벨 차이가 아니라, 기기의 시스템 글자 크기(텍스트 배율) 설정을 앱이 clamp 없이 그대로 반영하고 있었기 때문. 두 위젯 모두 고정 픽셀(24×24 원, 60px `leadingWidth`)로 여유 없이 튜닝되어 있어 배율이 커지면 콘텐츠가 넘치거나 줄바꿈됨
- `MaterialApp.router`에 `builder`를 추가해 `textScaler`를 `TextScaler.noScaling`으로 고정, 기기 설정과 무관하게 항상 배율 1.0으로 렌더링되도록 수정
- (향후 검토) 현재는 접근성 확대 기능을 앱 전체에서 완전히 무시함. 정식 출시 후 접근성 요구사항이 생기면 고정폭 UI 크롬만 배율 제한하고 본문 콘텐츠는 시스템 배율을 따르는 하이브리드 구조로 리팩터링 검토 필요

<br>
